### PR TITLE
Update ingest config example dataset

### DIFF
--- a/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -106,7 +106,7 @@
                                                 {
                                                     "name": "meta_ingestion_run_id",
                                                     "value": {
-                                                        "value": "@pipeline().RunId",
+                                                        "value": "@variables('run_id')",
                                                         "type": "Expression"
                                                     }
                                                 }

--- a/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -161,12 +161,12 @@
                                             "referenceName": "ds_dp_DataLake_Parquet",
                                             "type": "DatasetReference",
                                             "parameters": {
-                                                "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/@{pipeline().parameters.window_start}/@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                                "filename": {
+                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
                                                     "type": "Expression"
                                                 },
-                                                "filename": {
-                                                    "value": "@{item()['display_name']}.parquet",
+                                                "path": {
+                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -168,11 +168,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{variables('correlation_id')}.parquet",
+                                                    "value": "@{variables('run_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -207,7 +207,7 @@
                                     }
                                 },
                                 {
-                        "name": "correlation_id",
+                        "name": "run_id",
                         "type": "SetVariable",
                         "dependsOn": [],
                         "policy": {
@@ -216,9 +216,9 @@
                         },
                         "userProperties": [],
                         "typeProperties": {
-                            "variableName": "correlation_id",
+                            "variableName": "run_id",
                             "value": {
-                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "value": "@{if(empty(pipeline().parameters.run_id), pipeline().RunId, pipeline().parameters.run_id)}",
                                 "type": "Expression"
                             }
                         }
@@ -228,7 +228,7 @@
                         "type": "SetVariable",
                         "dependsOn": [
                             {
-                                "activity": "correlation_id",
+                                "activity": "run_id",
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
@@ -242,7 +242,7 @@
                         "typeProperties": {
                             "variableName": "automated_test_flag",
                             "value": {
-                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "value": "@startswith(variables('run_id'), pipeline().parameters.automated_test_prefix)",
                                 "type": "Expression"
                             }
                         }
@@ -256,7 +256,7 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "string"
                     },
                     "data_source_name": {
@@ -277,7 +277,7 @@
                     }
                 },
                 "variables": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "String"
                     },
                     "automated_test_flag": {

--- a/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -50,6 +50,12 @@
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
+                            },
+                            {
+                                "activity": "automated_test_flag",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
                             }
                         ],
                         "userProperties": [],
@@ -162,11 +168,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
+                                                    "value": "@{variables('correlation_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -199,7 +205,48 @@
                                             }
                                         }
                                     }
-                                }
+                                },
+                                {
+                        "name": "correlation_id",
+                        "type": "SetVariable",
+                        "dependsOn": [],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "correlation_id",
+                            "value": {
+                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "type": "Expression"
+                            }
+                        }
+                    },
+                    {
+                        "name": "automated_test_flag",
+                        "type": "SetVariable",
+                        "dependsOn": [
+                            {
+                                "activity": "correlation_id",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "automated_test_flag",
+                            "value": {
+                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "type": "Expression"
+                            }
+                        }
+                    }
                             ]
                         }
                     }
@@ -209,6 +256,9 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
+                    "correlation_id": {
+                        "type": "string"
+                    },
                     "data_source_name": {
                         "type": "string",
                         "defaultValue": "{{ pipeline_name }}"
@@ -221,8 +271,17 @@
                         "type": "string",
                         "defaultValue": "{{ window_start_default | default('2020-01-01') }}"
                     },
+                    "automated_test_prefix": {
+                        "type": "string",
+                        "defaultValue": "automated_test_"
+                    }
+                },
+                "variables": {
                     "correlation_id": {
-                        "type": "string"
+                        "type": "String"
+                    },
+                    "automated_test_flag": {
+                        "type": "Boolean"
                     }
                 },
                 "folder": {

--- a/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -172,7 +172,7 @@
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', variables('run_id')), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -106,7 +106,7 @@
                                                 {
                                                     "name": "meta_ingestion_run_id",
                                                     "value": {
-                                                        "value": "@pipeline().RunId",
+                                                        "value": "@variables('run_id')",
                                                         "type": "Expression"
                                                     }
                                                 }

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -161,12 +161,12 @@
                                             "referenceName": "ds_dp_DataLake_Parquet",
                                             "type": "DatasetReference",
                                             "parameters": {
-                                                "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/@{pipeline().parameters.window_start}/@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                                "filename": {
+                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
                                                     "type": "Expression"
                                                 },
-                                                "filename": {
-                                                    "value": "@{item()['display_name']}.parquet",
+                                                "path": {
+                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -50,6 +50,12 @@
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
+                            },
+                            {
+                                "activity": "automated_test_flag",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
                             }
                         ],
                         "userProperties": [],
@@ -162,11 +168,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
+                                                    "value": "@{variables('correlation_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -201,6 +207,47 @@
                                     }
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "correlation_id",
+                        "type": "SetVariable",
+                        "dependsOn": [],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "correlation_id",
+                            "value": {
+                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "type": "Expression"
+                            }
+                        }
+                    },
+                    {
+                        "name": "automated_test_flag",
+                        "type": "SetVariable",
+                        "dependsOn": [
+                            {
+                                "activity": "correlation_id",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "automated_test_flag",
+                            "value": {
+                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "type": "Expression"
+                            }
                         }
                     },
                     {
@@ -242,6 +289,9 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
+                    "correlation_id": {
+                        "type": "string"
+                    },
                     "data_source_name": {
                         "type": "string",
                         "defaultValue": "{{ pipeline_name }}"
@@ -254,8 +304,17 @@
                         "type": "string",
                         "defaultValue": "{{ window_start_default | default('2020-01-01') }}"
                     },
+                    "automated_test_prefix": {
+                        "type": "string",
+                        "defaultValue": "automated_test_"
+                    }
+                },
+                "variables": {
                     "correlation_id": {
-                        "type": "string"
+                        "type": "String"
+                    },
+                    "automated_test_flag": {
+                        "type": "Boolean"
                     }
                 },
                 "folder": {

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -172,7 +172,7 @@
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', variables('run_id')), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -168,11 +168,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{variables('correlation_id')}.parquet",
+                                                    "value": "@{variables('run_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -210,7 +210,7 @@
                         }
                     },
                     {
-                        "name": "correlation_id",
+                        "name": "run_id",
                         "type": "SetVariable",
                         "dependsOn": [],
                         "policy": {
@@ -219,9 +219,9 @@
                         },
                         "userProperties": [],
                         "typeProperties": {
-                            "variableName": "correlation_id",
+                            "variableName": "run_id",
                             "value": {
-                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "value": "@{if(empty(pipeline().parameters.run_id), pipeline().RunId, pipeline().parameters.run_id)}",
                                 "type": "Expression"
                             }
                         }
@@ -231,7 +231,7 @@
                         "type": "SetVariable",
                         "dependsOn": [
                             {
-                                "activity": "correlation_id",
+                                "activity": "run_id",
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
@@ -245,7 +245,7 @@
                         "typeProperties": {
                             "variableName": "automated_test_flag",
                             "value": {
-                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "value": "@startswith(variables('run_id'), pipeline().parameters.automated_test_prefix)",
                                 "type": "Expression"
                             }
                         }
@@ -289,7 +289,7 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "string"
                     },
                     "data_source_name": {
@@ -310,7 +310,7 @@
                     }
                 },
                 "variables": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "String"
                     },
                     "automated_test_flag": {

--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
@@ -1,15 +1,15 @@
 {
     "gx_directory_path": "/dbfs/great_expectations/",
-    "dataset_name": "SalesLT",
+    "dataset_name": "movies.keywords",
     "datasource_config": [
         {
-            "datasource_name": "SalesLT.Product",
+            "datasource_name": "movies.keywords",
             "datasource_type": "parquet",
-            "data_location": "abfss://raw@{ADLS_ACCOUNT}.dfs.core.windows.net/example_azuresql_1/SalesLT.Product/v1/*/*/*",
-            "expectation_suite_name": "SalesLT_product_suite",
+            "data_location": "abfss://raw@{ADLS_ACCOUNT}.dfs.core.windows.net/Ingest_AzureSql_Example/movies.keywords/v1/*/*/*",
+            "expectation_suite_name": "movies.keywords_suite",
             "validation_config": [
                 {
-                    "column_name": "ProductID",
+                    "column_name": "id",
                     "expectations": [
                         {
                             "expectation_type": "expect_column_values_to_not_be_null",

--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/ingest_sources/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/ingest_sources/Ingest_AzureSql_Example.json
@@ -44,7 +44,7 @@
             "table": "ratings_small",
             "columns": "[userId], [movieId], [rating], [timestamp]",
             "load_type": "delta",
-            "delta_date_column": "DATEADD(MINUTE,[timestamp]/60,'1970-01-01 00:00:00.0')",
+            "delta_date_column": "DATEADD(SECOND,[timestamp],'1970-01-01')",
             "delta_upsert_key": "[userId], [movieId]"
         }
     ]

--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/ingest_sources/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/ingest_sources/Ingest_AzureSql_Example.json
@@ -1,40 +1,51 @@
 {
-    "data_source_name": "example_azuresql_1",
+    "data_source_name": "Ingest_AzureSql_Example",
     "data_source_type": "azure_sql",
     "enabled": true,
     "ingest_entities": [
         {
             "version": 1,
-            "display_name": "SalesLT.Product",
+            "display_name": "movies.keywords",
             "enabled": true,
-            "schema": "SalesLT",
-            "table": "Product",
-            "columns": "*",
+            "schema": "movies",
+            "table": "keywords",
+            "columns": "[id], [keywords]",
             "load_type": "full",
             "delta_date_column": null,
             "delta_upsert_key": null
         },
         {
             "version": 1,
-            "display_name": "SalesLT.SalesOrderHeader",
+            "display_name": "movies.links",
             "enabled": true,
-            "schema": "SalesLT",
-            "table": "SalesOrderHeader",
-            "columns": "SalesOrderID, RevisionNumber, OrderDate, DueDate, ShipDate, Status, OnlineOrderFlag, SalesOrderNumber, PurchaseOrderNumber, AccountNumber, CustomerID, ShipToAddressID, BillToAddressID, ShipMethod, CreditCardApprovalCode, SubTotal, TaxAmt, Freight, TotalDue, Comment, rowguid, ModifiedDate",
-            "load_type": "delta",
-            "delta_date_column": "ModifiedDate",
-            "delta_upsert_key": "SalesOrderID"
+            "schema": "movies",
+            "table": "links",
+            "columns": "[movieId], [imdbId], [tmdbId]",
+            "load_type": "full",
+            "delta_date_column": null,
+            "delta_upsert_key": null
         },
         {
             "version": 1,
-            "display_name": "SalesLT.SalesOrderDetailID",
+            "display_name": "movies.movies_metadata",
             "enabled": true,
-            "schema": "SalesLT",
-            "table": "SalesOrderDetail",
-            "columns": "SalesOrderID, SalesOrderDetailID, OrderQty, ProductID, UnitPrice, UnitPriceDiscount, LineTotal, rowguid, ModifiedDate",
+            "schema": "movies",
+            "table": "movies_metadata",
+            "columns": "[adult], [belongs_to_collection], [budget], [genres], [homepage], [id], [imdb_id], [original_language], [original_title], [overview], [popularity], [poster_path], [production_companies], [production_countries], [release_date], [revenue], [runtime], [spoken_languages], [status], [tagline], [title], [video], [vote_average], [vote_count]",
+            "load_type": "full",
+            "delta_date_column": null,
+            "delta_upsert_key": null
+        },
+        {
+            "version": 1,
+            "display_name": "movies.ratings_small",
+            "enabled": true,
+            "schema": "movies",
+            "table": "ratings_small",
+            "columns": "[userId], [movieId], [rating], [timestamp]",
             "load_type": "delta",
-            "delta_date_column": "ModifiedDate",
-            "delta_upsert_key": "SalesOrderID, SalesOrderDetailID"
+            "delta_date_column": "DATEADD(MINUTE,[timestamp]/60,'1970-01-01 00:00:00.0')",
+            "delta_upsert_key": "[userId], [movieId]"
         }
     ]
 }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -173,7 +173,7 @@
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', variables('run_id')), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -216,11 +216,11 @@
                     },
                     "window_end": {
                         "type": "string",
-                        "defaultValue": "2020-01-31"
+                        "defaultValue": "2010-01-31"
                     },
                     "window_start": {
                         "type": "string",
-                        "defaultValue": "2020-01-01"
+                        "defaultValue": "2010-01-01"
                     },
                     "correlation_id": {
                         "type": "string"

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -107,7 +107,7 @@
                                                 {
                                                     "name": "meta_ingestion_run_id",
                                                     "value": {
-                                                        "value": "@pipeline().RunId",
+                                                        "value": "@variables('run_id')",
                                                         "type": "Expression"
                                                     }
                                                 }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -169,11 +169,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{variables('correlation_id')}.parquet",
+                                                    "value": "@{variables('run_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -211,7 +211,7 @@
                         }
                     },
                     {
-                        "name": "correlation_id",
+                        "name": "run_id",
                         "type": "SetVariable",
                         "dependsOn": [],
                         "policy": {
@@ -220,9 +220,9 @@
                         },
                         "userProperties": [],
                         "typeProperties": {
-                            "variableName": "correlation_id",
+                            "variableName": "run_id",
                             "value": {
-                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "value": "@{if(empty(pipeline().parameters.run_id), pipeline().RunId, pipeline().parameters.run_id)}",
                                 "type": "Expression"
                             }
                         }
@@ -232,7 +232,7 @@
                         "type": "SetVariable",
                         "dependsOn": [
                             {
-                                "activity": "correlation_id",
+                                "activity": "run_id",
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
@@ -246,7 +246,7 @@
                         "typeProperties": {
                             "variableName": "automated_test_flag",
                             "value": {
-                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "value": "@startswith(variables('run_id'), pipeline().parameters.automated_test_prefix)",
                                 "type": "Expression"
                             }
                         }
@@ -257,7 +257,7 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "string"
                     },
                     "data_source_name": {
@@ -278,7 +278,7 @@
                     }
                 },
                 "variables": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "String"
                     },
                     "automated_test_flag": {

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -51,6 +51,12 @@
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
+                            },
+                            {
+                                "activity": "automated_test_flag",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
                             }
                         ],
                         "userProperties": [],
@@ -163,11 +169,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
+                                                    "value": "@{variables('correlation_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -203,6 +209,47 @@
                                 }
                             ]
                         }
+                    },
+                    {
+                        "name": "correlation_id",
+                        "type": "SetVariable",
+                        "dependsOn": [],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "correlation_id",
+                            "value": {
+                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "type": "Expression"
+                            }
+                        }
+                    },
+                    {
+                        "name": "automated_test_flag",
+                        "type": "SetVariable",
+                        "dependsOn": [
+                            {
+                                "activity": "correlation_id",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "automated_test_flag",
+                            "value": {
+                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "type": "Expression"
+                            }
+                        }
                     }
                 ],
                 "policy": {
@@ -210,6 +257,9 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
+                    "correlation_id": {
+                        "type": "string"
+                    },
                     "data_source_name": {
                         "type": "string",
                         "defaultValue": "Ingest_AzureSql_Example"
@@ -222,8 +272,17 @@
                         "type": "string",
                         "defaultValue": "2010-01-01"
                     },
+                    "automated_test_prefix": {
+                        "type": "string",
+                        "defaultValue": "automated_test_"
+                    }
+                },
+                "variables": {
                     "correlation_id": {
-                        "type": "string"
+                        "type": "String"
+                    },
+                    "automated_test_flag": {
+                        "type": "Boolean"
                     }
                 },
                 "folder": {

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example.json
@@ -162,12 +162,12 @@
                                             "referenceName": "ds_dp_DataLake_Parquet",
                                             "type": "DatasetReference",
                                             "parameters": {
-                                                "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/@{pipeline().parameters.window_start}/@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                                "filename": {
+                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
                                                     "type": "Expression"
                                                 },
-                                                "filename": {
-                                                    "value": "@{item()['display_name']}.parquet",
+                                                "path": {
+                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -169,11 +169,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{variables('correlation_id')}.parquet",
+                                                    "value": "@{variables('run_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -211,7 +211,7 @@
                         }
                     },
                     {
-                        "name": "correlation_id",
+                        "name": "run_id",
                         "type": "SetVariable",
                         "dependsOn": [],
                         "policy": {
@@ -220,9 +220,9 @@
                         },
                         "userProperties": [],
                         "typeProperties": {
-                            "variableName": "correlation_id",
+                            "variableName": "run_id",
                             "value": {
-                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "value": "@{if(empty(pipeline().parameters.run_id), pipeline().RunId, pipeline().parameters.run_id)}",
                                 "type": "Expression"
                             }
                         }
@@ -232,7 +232,7 @@
                         "type": "SetVariable",
                         "dependsOn": [
                             {
-                                "activity": "correlation_id",
+                                "activity": "run_id",
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
@@ -246,7 +246,7 @@
                         "typeProperties": {
                             "variableName": "automated_test_flag",
                             "value": {
-                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "value": "@startswith(variables('run_id'), pipeline().parameters.automated_test_prefix)",
                                 "type": "Expression"
                             }
                         }
@@ -290,7 +290,7 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "string"
                     },
                     "data_source_name": {
@@ -311,7 +311,7 @@
                     }
                 },
                 "variables": {
-                    "correlation_id": {
+                    "run_id": {
                         "type": "String"
                     },
                     "automated_test_flag": {

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -173,7 +173,7 @@
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.run_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', variables('run_id')), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -249,11 +249,11 @@
                     },
                     "window_end": {
                         "type": "string",
-                        "defaultValue": "2020-01-31"
+                        "defaultValue": "2010-01-31"
                     },
                     "window_start": {
                         "type": "string",
-                        "defaultValue": "2020-01-01"
+                        "defaultValue": "2010-01-01"
                     },
                     "correlation_id": {
                         "type": "string"

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -107,7 +107,7 @@
                                                 {
                                                     "name": "meta_ingestion_run_id",
                                                     "value": {
-                                                        "value": "@pipeline().RunId",
+                                                        "value": "@variables('run_id')",
                                                         "type": "Expression"
                                                     }
                                                 }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -51,6 +51,12 @@
                                 "dependencyConditions": [
                                     "Succeeded"
                                 ]
+                            },
+                            {
+                                "activity": "automated_test_flag",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
                             }
                         ],
                         "userProperties": [],
@@ -163,11 +169,11 @@
                                             "type": "DatasetReference",
                                             "parameters": {
                                                 "filename": {
-                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
+                                                    "value": "@{variables('correlation_id')}.parquet",
                                                     "type": "Expression"
                                                 },
                                                 "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
+                                                    "value": "@{pipeline().parameters.data_source_name}@{if(variables('automated_test_flag'), concat('/automated_tests/', pipeline().parameters.correlation_id), '')}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }
@@ -202,6 +208,47 @@
                                     }
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "correlation_id",
+                        "type": "SetVariable",
+                        "dependsOn": [],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "correlation_id",
+                            "value": {
+                                "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                "type": "Expression"
+                            }
+                        }
+                    },
+                    {
+                        "name": "automated_test_flag",
+                        "type": "SetVariable",
+                        "dependsOn": [
+                            {
+                                "activity": "correlation_id",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "userProperties": [],
+                        "typeProperties": {
+                            "variableName": "automated_test_flag",
+                            "value": {
+                                "value": "@startswith(variables('correlation_id'), pipeline().parameters.automated_test_prefix)",
+                                "type": "Expression"
+                            }
                         }
                     },
                     {
@@ -243,6 +290,9 @@
                     "cancelAfter": {}
                 },
                 "parameters": {
+                    "correlation_id": {
+                        "type": "string"
+                    },
                     "data_source_name": {
                         "type": "string",
                         "defaultValue": "Ingest_AzureSql_Example"
@@ -255,8 +305,17 @@
                         "type": "string",
                         "defaultValue": "2010-01-01"
                     },
+                    "automated_test_prefix": {
+                        "type": "string",
+                        "defaultValue": "automated_test_"
+                    }
+                },
+                "variables": {
                     "correlation_id": {
-                        "type": "string"
+                        "type": "String"
+                    },
+                    "automated_test_flag": {
+                        "type": "Boolean"
                     }
                 },
                 "folder": {

--- a/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/data_factory/pipelines/Ingest_AzureSql_Example_DQ.json
@@ -162,12 +162,12 @@
                                             "referenceName": "ds_dp_DataLake_Parquet",
                                             "type": "DatasetReference",
                                             "parameters": {
-                                                "path": {
-                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/@{pipeline().parameters.window_start}/@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}",
+                                                "filename": {
+                                                    "value": "@{if(empty(pipeline().parameters.correlation_id), pipeline().RunId, pipeline().parameters.correlation_id)}.parquet",
                                                     "type": "Expression"
                                                 },
-                                                "filename": {
-                                                    "value": "@{item()['display_name']}.parquet",
+                                                "path": {
+                                                    "value": "@{pipeline().parameters.data_source_name}/@{item()['display_name']}/v@{string(item()['version'])}/@{item()['load_type']}/rundate=@{replace(utcNow(),':','')}/@{if(equals(item()['load_type'], 'delta'), concat('window=',pipeline().parameters.window_start,'_', pipeline().parameters.window_end), '')}",
                                                     "type": "Expression"
                                                 }
                                             }

--- a/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/azure_data_ingest.feature
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/azure_data_ingest.feature
@@ -11,4 +11,4 @@ Feature:Azure Data Ingest
 
     Examples: Output files
     |parameters|output_files|
-    |{"window_start" : "2020-01-01", "window_end": "2020-01-31"}|["movies.keywords", "movies.links", "movies.movies_metadata", "movies.ratings_small"]|
+    |{"window_start" : "2010-01-01", "window_end": "2010-01-31"}|["movies.keywords", "movies.links", "movies.movies_metadata", "movies.ratings_small"]|

--- a/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/azure_data_ingest.feature
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/azure_data_ingest.feature
@@ -11,4 +11,4 @@ Feature:Azure Data Ingest
 
     Examples: Output files
     |parameters|output_files|
-    |{"window_start" : "2020-01-01", "window_end": "2020-01-31"}|["SalesLT.Product.parquet", "SalesLT.SalesOrderDetailID.parquet", "SalesLT.SalesOrderHeader.parquet"]|
+    |{"window_start" : "2020-01-01", "window_end": "2020-01-31"}|["movies.keywords", "movies.links", "movies.movies_metadata", "movies.ratings_small"]|

--- a/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/environment.py
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/environment.py
@@ -2,7 +2,7 @@ from behave import use_fixture
 
 from fixtures import azure_adls_clean_up
 
-SQL_DB_INGEST_DIRECTORY_NAME = "example_azuresql_1"
+SQL_DB_INGEST_DIRECTORY_NAME = "Ingest_AzureSql_Example"
 
 
 def before_scenario(context, scenario):

--- a/utils/test/e2e/shared_steps.py
+++ b/utils/test/e2e/shared_steps.py
@@ -31,9 +31,9 @@ adls_client = DataLakeServiceClient(account_url=ADLS_URL, credential=credential)
 def trigger_adf_pipeline(context, pipeline_name: str, parameters: str):
     context.start_time = datetime.now()
     parameters = json.loads(parameters)
-    correlation_id = f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"
-    context.correlation_id = correlation_id
-    parameters.update({"correlation_id": correlation_id})
+    run_id = f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"
+    context.run_id = run_id
+    parameters.update({"run_id": run_id})
 
     run_response = create_adf_pipeline_run(
         adf_client,
@@ -70,7 +70,7 @@ def pipeline_has_finished_with_state(context, pipeline_name: str, state: str):
 )
 def check_all_files_present_in_adls(context, output_files, container_name, directory_name):
     expected_files_list = json.loads(output_files)
-    test_directory_name = f"{directory_name}/automated_tests/{context.correlation_id}"
+    test_directory_name = f"{directory_name}/automated_tests/{context.run_id}"
     assert all_files_present_in_adls(adls_client, container_name, test_directory_name, expected_files_list)
 
 

--- a/utils/test/e2e/shared_steps.py
+++ b/utils/test/e2e/shared_steps.py
@@ -33,7 +33,7 @@ def trigger_adf_pipeline(context, pipeline_name: str, parameters: str):
     parameters = json.loads(parameters)
     correlation_id = f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"
     context.correlation_id = correlation_id
-    parameters.update({"correlation_id": f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"})
+    parameters.update({"correlation_id": correlation_id})
 
     run_response = create_adf_pipeline_run(
         adf_client,
@@ -70,7 +70,8 @@ def pipeline_has_finished_with_state(context, pipeline_name: str, state: str):
 )
 def check_all_files_present_in_adls(context, output_files, container_name, directory_name):
     expected_files_list = json.loads(output_files)
-    assert all_files_present_in_adls(adls_client, container_name, directory_name, expected_files_list)
+    test_directory_name = f"{directory_name}/automated_tests/{context.correlation_id}"
+    assert all_files_present_in_adls(adls_client, container_name, test_directory_name, expected_files_list)
 
 
 @step("the ADF pipeline completed in less than {seconds} seconds")

--- a/utils/test/e2e/shared_steps.py
+++ b/utils/test/e2e/shared_steps.py
@@ -31,11 +31,9 @@ adls_client = DataLakeServiceClient(account_url=ADLS_URL, credential=credential)
 def trigger_adf_pipeline(context, pipeline_name: str, parameters: str):
     context.start_time = datetime.now()
     parameters = json.loads(parameters)
-    correlation_id = f"automated_test_{uuid.uuid4()}"
+    correlation_id = f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"
     context.correlation_id = correlation_id
-    parameters.update(
-        {"correlation_id": f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"}
-    )
+    parameters.update({"correlation_id": f"{AUTOMATED_TEST_OUTPUT_DIRECTORY_PREFIX}_{uuid.uuid4()}"})
 
     run_response = create_adf_pipeline_run(
         adf_client,
@@ -63,23 +61,16 @@ def poll_adf_pipeline(context, seconds: str):
 
 @step("the ADF pipeline {pipeline_name} has finished with state {state}")
 def pipeline_has_finished_with_state(context, pipeline_name: str, state: str):
-    pipeline_run = get_adf_pipeline_run(
-        adf_client, AZURE_RESOURCE_GROUP_NAME, AZURE_DATA_FACTORY_NAME, context.run_id
-    )
+    pipeline_run = get_adf_pipeline_run(adf_client, AZURE_RESOURCE_GROUP_NAME, AZURE_DATA_FACTORY_NAME, context.run_id)
     assert pipeline_run.status == state
 
 
 @then(
-    "the files {output_files} are present in the ADLS container {container_name} in the directory "
-    "{directory_name}"
+    "the files {output_files} are present in the ADLS container {container_name} in the directory " "{directory_name}"
 )
-def check_all_files_present_in_adls(
-    context, output_files, container_name, directory_name
-):
+def check_all_files_present_in_adls(context, output_files, container_name, directory_name):
     expected_files_list = json.loads(output_files)
-    assert all_files_present_in_adls(
-        adls_client, container_name, directory_name, expected_files_list
-    )
+    assert all_files_present_in_adls(adls_client, container_name, directory_name, expected_files_list)
 
 
 @step("the ADF pipeline completed in less than {seconds} seconds")


### PR DESCRIPTION
Update example ingest pipelines to use movies dataset.
ADF pipeline amendments to update output path (also updated in jinja template)
Fix to E2E test utils to ensure only the test directory is checked for output files