### PR TITLE
Bug: Fix makefile test statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ setup_dev_environment:
 
 test:
 	python -m pytest de_workloads/ingest/Ingest_AzureSql_Example/tests/unit
-	python -m pytest datastacks_tests/unit
+	python -m pytest datastacks/tests/unit
 
 test_e2e:
 	behave de_workloads/ingest/Ingest_AzureSql_Example/tests/end_to_end/features/azure_data_ingest.feature


### PR DESCRIPTION
We have changed the folder path to the datastacks tests, but have forgotten to also amend this path in the makefile. This PR fixes this.