### PR TITLE
Feat: Extend example validation suite

### DIFF
--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
@@ -39,7 +39,7 @@
                     "expectations": [
                         {
                             "expectation_type": "expect_column_values_to_be_in_set",
-                            "expectation_kwargs": {"value_set": ["TRUE", "FALSE"]}
+                            "expectation_kwargs": {"value_set": ["True", "False"]}
                         }
                     ]
                 },

--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
@@ -48,7 +48,7 @@
                     "expectations": [
                         {
                             "expectation_type": "expect_column_values_to_match_regex",
-                            "expectation_kwargs": {"regex": "^tt\d{7}$"}
+                            "expectation_kwargs": {"regex": "^tt\\d{7}$"}
                         }
                     ]
                 }                

--- a/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/config/data_quality/ingest_dq.json
@@ -18,6 +18,41 @@
                     ]
                 }
             ]
+        },
+        {
+            "datasource_name": "movies.movies_metadata",
+            "datasource_type": "parquet",
+            "data_location": "abfss://raw@{ADLS_ACCOUNT}.dfs.core.windows.net/Ingest_AzureSql_Example/movies.movies_metadata/v1/*/*/*",
+            "expectation_suite_name": "movies.movies_metadata_suite",
+            "validation_config": [
+                {
+                    "column_name": "status",
+                    "expectations": [
+                        {
+                            "expectation_type": "expect_column_values_to_be_in_set",
+                            "expectation_kwargs": {"value_set": ["Canceled", "In Production", "Planned", "Post Production", "Released", "Rumored"]}
+                        }
+                    ]
+                },
+                {
+                    "column_name": "adult",
+                    "expectations": [
+                        {
+                            "expectation_type": "expect_column_values_to_be_in_set",
+                            "expectation_kwargs": {"value_set": ["TRUE", "FALSE"]}
+                        }
+                    ]
+                },
+                {
+                    "column_name": "imdb_id",
+                    "expectations": [
+                        {
+                            "expectation_type": "expect_column_values_to_match_regex",
+                            "expectation_kwargs": {"regex": "^tt\d{7}$"}
+                        }
+                    ]
+                }                
+            ]
         }
     ]
 }


### PR DESCRIPTION
In order to fully test our data quality jobs, we need to have functional validation suites with both passing and failing validators. This PR adds that